### PR TITLE
Ay train details

### DIFF
--- a/WorkforceManagement/Controllers/EmployeeController.cs
+++ b/WorkforceManagement/Controllers/EmployeeController.cs
@@ -11,12 +11,10 @@ using Microsoft.Extensions.Configuration;
 using WorkforceManagement.Models;
 using System.Data.SqlClient;
 
-<<<<<<< HEAD
+
 
 // For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
-=======
->>>>>>> master
 namespace WorkforceManagement.Controllers
 {
     public class EmployeeController : Controller

--- a/WorkforceManagement/Controllers/TrainingController.cs
+++ b/WorkforceManagement/Controllers/TrainingController.cs
@@ -67,19 +67,37 @@ namespace WorkforceManagement.Controllers
                 t.StartDate,
                 t.EndDate,
                 t.ProgDesc,
-                t.MaxAttendees
+                t.MaxAttendees,
+                et.Id,
+                et.EmployeeId,
+                et.TrainingProgramId,
+                e.Id,
+                e.FirstName,
+                e.LastName
                 from TrainingProgram t
+                LEFT JOIN EmployeeTraining et ON t.Id = et.TrainingProgramId
+				LEFT JOIN Employee e ON  e.Id = et.EmployeeId
                 WHERE t.Id = {id}";
 
             using (IDbConnection conn = Connection)
             {
-                Training trainingProgram = (await conn.QueryAsync<Training>(sql)).ToList().Single();
+                Training program = new Training();
+                var deptQuery = await conn.QueryAsync<Training, Employees, Training>(sql,
+                    (training, employee) =>
+                    {
 
-                if (trainingProgram == null)
-                {
-                    return NotFound();
-                }
-                return View(trainingProgram);
+                        program.Id = training.Id;
+                        program.ProgName = training.ProgName;
+                        program.StartDate = training.StartDate;
+                        program.EndDate = training.EndDate;
+                        program.MaxAttendees = training.MaxAttendees;
+                        program.ProgDesc = training.ProgDesc;
+
+
+                        program.EmployeeList.Add(employee);
+                        return training;
+                    });
+                return View(program);
             }
         }
 

--- a/WorkforceManagement/Models/Training.cs
+++ b/WorkforceManagement/Models/Training.cs
@@ -32,6 +32,8 @@ namespace WorkforceManagement.Models
         [Display(Name = "Description")]
         public string ProgDesc { get; set; }
 
+        [Display(Name = "Attending Employees")]
+        public List<Employees> EmployeeList { get; set; } = new List<Employees>();
     }
 
 }

--- a/WorkforceManagement/Views/Training/Details.cshtml
+++ b/WorkforceManagement/Views/Training/Details.cshtml
@@ -1,0 +1,63 @@
+﻿@model WorkforceManagement.Models.Training
+
+@{
+    ViewData["Title"] = "Training Program Details";
+}
+
+<h2>@ViewData["Title"]</h2>
+
+<div>
+    <h4>@Html.DisplayFor(model => model.ProgName)</h4>
+    <hr />
+    <dl class="dl-horizontal">
+        <dt>
+            @Html.DisplayNameFor(model => model.StartDate)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.StartDate)
+        </dd>
+    </dl>
+    <dl class="dl-horizontal">
+        <dt>
+            @Html.DisplayNameFor(model => model.EndDate)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.EndDate)
+        </dd>
+    </dl>
+    <dl class="dl-horizontal">
+        <dt>
+            @Html.DisplayNameFor(model => model.MaxAttendees)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.MaxAttendees)
+        </dd>
+    </dl>
+    <dl class="dl-horizontal">
+        <dt>
+            @Html.DisplayNameFor(model => model.ProgDesc)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.ProgDesc)
+        </dd>
+        <dt>
+            @Html.DisplayNameFor(model => model.EmployeeList)
+        </dt>
+        <dd>
+            
+            <ul>
+                @foreach (var emp in Model.EmployeeList)
+                {
+                    <li>
+                        @Html.DisplayFor(modelItem => emp.FirstName)
+                        @Html.DisplayFor(modelItem => emp.LastName)
+                    </li>
+                }
+            </ul>
+        </dd>
+    </dl>
+</div>
+<div>
+
+    <a asp-action="Index">Back to List</a>
+</div>


### PR DESCRIPTION
Please structure your pull requests this way:

Purpose of PR
To Fulfill ticket #20:
Given user is viewing the list of training programs
When the user clicks on a training program
Then the user should see all details of that training program
And any employees that are currently attending the program

Issue number this request impacts ------
#20

Description of what was changed:

Added in StartDate and EndDate to the Training Create Method on the Training Controller

Added in StartDate and EndDate to the Index of the Training Folder

Added to Create Method in Training Controller so that only Training Programs set in the future are shown

Added in SQL statement for Details Method for Training Controller

Created the Details view in the training folder

Added in list of employees onto Training Model

Thorough list of steps to test

1. git checkout into master
2. git fetch --all
3. git checkout ay-trainDetails
4. ls
5. start WorkforceManagement.sln
6. run project
7. in brower - click on Training Programs
8. then click on Details button to see the details of a Training Program (there should be a list of attending employees)

if you don't do this you will be
FIRED